### PR TITLE
feat: set WireMock client default port when only one server (refs #36)

### DIFF
--- a/example/src/test/java/app/TodoClientTests.java
+++ b/example/src/test/java/app/TodoClientTests.java
@@ -2,10 +2,9 @@ package app;
 
 import java.util.List;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.maciejwalkowiak.wiremock.spring.ConfigureWireMock;
 import com.maciejwalkowiak.wiremock.spring.EnableWireMock;
-import com.maciejwalkowiak.wiremock.spring.InjectWireMock;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,12 +23,13 @@ class TodoClientTests {
     @Autowired
     private TodoClient todoClient;
 
-    @InjectWireMock("todo-client")
-    private WireMockServer wiremock;
-
     @Test
     void usesJavaStubbing() {
-        wiremock.stubFor(get("/").willReturn(aResponse()
+        /**
+         * If there is only one WireMock configured, you can access WireMock in this static way.
+         * If there are several WireMocks configured, you have to use InjectWireMock. 
+         */
+        WireMock.stubFor(get("/").willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
                 .withBody("""
                         [

--- a/wiremock-spring-boot/src/main/java/com/maciejwalkowiak/wiremock/spring/WireMockContextCustomizer.java
+++ b/wiremock-spring-boot/src/main/java/com/maciejwalkowiak/wiremock/spring/WireMockContextCustomizer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -52,11 +53,14 @@ public class WireMockContextCustomizer implements ContextCustomizer {
     @Override
     public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
         for (ConfigureWireMock configureWiremock : configuration) {
-            resolveOrCreateWireMockServer(context, configureWiremock);
+            WireMockServer wireMockServer = resolveOrCreateWireMockServer(context, configureWiremock);
+            if (configuration.size() == 1) {
+                WireMock.configureFor(wireMockServer.port());
+            }
         }
     }
 
-    private void resolveOrCreateWireMockServer(ConfigurableApplicationContext context, ConfigureWireMock options) {
+    private WireMockServer resolveOrCreateWireMockServer(ConfigurableApplicationContext context, ConfigureWireMock options) {
         WireMockServer wireMockServer = Store.INSTANCE.findWireMockInstance(context, options.name());
 
         if (wireMockServer == null) {
@@ -96,9 +100,13 @@ public class WireMockContextCustomizer implements ContextCustomizer {
                 LOGGER.debug("Adding property '{}' to Spring application context", property);
                 TestPropertyValues.of(property).applyTo(context.getEnvironment());
             }
+
+            return newServer;
         } else {
             LOGGER.info("WireMockServer with name '{}' is already configured", options.name());
         }
+
+        return wireMockServer;
     }
 
     private static void applyCustomizers(ConfigureWireMock options, WireMockConfiguration serverOptions) {


### PR DESCRIPTION
Fixes #36