### PR TITLE
Update WireMock dependency to 3.9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 }
 
 dependencies {
-	api 'org.wiremock:wiremock-standalone:3.9.1'
+	api 'org.wiremock:wiremock-standalone:3.9.2'
 	api "org.springframework.boot:spring-boot-test:3.3.4"
 	api "org.springframework:spring-test:6.1.13"
 	api "org.slf4j:slf4j-api:2.0.16"


### PR DESCRIPTION
Upgraded the WireMock standalone version from 3.9.1 to 3.9.2.

<!-- Please describe your pull request here. -->

## References

- https://github.com/wiremock/wiremock/releases/tag/3.9.2

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
