### PR TITLE
Use wiremock-jetty12 thin JAR instead of the standalone JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,21 @@ apply plugin: "org.wiremock.tools.gradle.wiremock-extension-convention"
 group 'org.wiremock.integrations'
 
 // Because older version is set in wiremock-extension-convention
-def wiremockVersion = "3.9.2"
+def wiremockVersion = "3.10.0"
+
+configurations {
+	all*.exclude group: 'org.eclipse.jetty', module: 'jetty-servlet'
+	all*.exclude group: 'org.eclipse.jetty', module: 'jetty-servlets'
+	all*.exclude group: 'org.eclipse.jetty', module: 'jetty-webapp'
+	all*.exclude group: 'org.eclipse.jetty.http2', module: 'http2-server'
+}
 
 dependencies {
-	api "org.wiremock:wiremock-standalone:${wiremockVersion}"
-	compileOnly "org.wiremock:wiremock:${wiremockVersion}"
-	shadow "org.wiremock:wiremock:${wiremockVersion}"
+	implementation enforcedPlatform("org.eclipse.jetty:jetty-bom:12.0.8")
+	api "org.wiremock:wiremock-jetty12:${wiremockVersion}"
+
+	//	compileOnly "org.wiremock:wiremock:${wiremockVersion}"
+	//	shadow "org.wiremock:wiremock:${wiremockVersion}"
 	api "org.springframework.boot:spring-boot-test:3.3.4"
 	api "org.springframework:spring-test:6.1.13"
 	api "org.slf4j:slf4j-api:2.0.16"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	api "org.slf4j:slf4j-api:2.0.16"
 	api 'org.junit.jupiter:junit-jupiter-api:5.11.2'
 
-	testImplementation "org.wiremock:wiremock:${wiremockVersion}"
+	testImplementation "org.wiremock:wiremock-jetty12:${wiremockVersion}"
 	testImplementation "org.springframework.boot:spring-boot-starter-test:3.3.4"
 	testImplementation 'org.assertj:assertj-core:3.26.3'
 	testImplementation platform('org.junit:junit-bom:5.11.2')

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ configurations {
 }
 
 dependencies {
-	implementation platform("org.eclipse.jetty:jetty-bom:12.0.8")
+	implementation platform("org.eclipse.jetty:jetty-bom:12.0.15")
 	api "org.wiremock:wiremock-jetty12:${wiremockVersion}"
 
 	api "org.springframework.boot:spring-boot-test:3.3.4"

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,9 @@ configurations {
 }
 
 dependencies {
-	implementation enforcedPlatform("org.eclipse.jetty:jetty-bom:12.0.8")
+	implementation platform("org.eclipse.jetty:jetty-bom:12.0.8")
 	api "org.wiremock:wiremock-jetty12:${wiremockVersion}"
 
-	//	compileOnly "org.wiremock:wiremock:${wiremockVersion}"
-	//	shadow "org.wiremock:wiremock:${wiremockVersion}"
 	api "org.springframework.boot:spring-boot-test:3.3.4"
 	api "org.springframework:spring-test:6.1.13"
 	api "org.slf4j:slf4j-api:2.0.16"

--- a/src/test/java/usecases/NotEnabledTest.java
+++ b/src/test/java/usecases/NotEnabledTest.java
@@ -6,11 +6,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import org.apache.hc.client5.http.HttpHostConnectException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
-import wiremock.org.apache.hc.client5.http.HttpHostConnectException;
 
 @SpringBootTest
 class NotEnabledTest {


### PR DESCRIPTION
Switch to WireMock's Jetty 12 JAR, avoiding the need to depend on the (much larger) standalone JAR.

In draft as this depends on some currently unreleased changes to WireMock's core.