### PR TITLE
fix: Automatic-Module-Name in manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,13 @@ apply plugin: "org.wiremock.tools.gradle.wiremock-extension-convention"
 
 group 'org.wiremock.integrations'
 
+jar {
+	manifest {
+		attributes 'name': project.name
+		attributes 'Automatic-Module-Name': project.group + "." + project.name
+	}
+}
+
 // Because older version is set in wiremock-extension-convention
 def wiremockVersion = "3.12.0"
 


### PR DESCRIPTION
`META-INF/MANIFEST.MF` will now contain:

```
Manifest-Version: 1.0
name: wiremock-spring-boot
Automatic-Module-Name: org.wiremock.integrations.wiremock-spring-boot
```