### PR TITLE
feat: Separate wiremock logger name with dot

### DIFF
--- a/src/main/java/org/wiremock/spring/internal/Slf4jNotifier.java
+++ b/src/main/java/org/wiremock/spring/internal/Slf4jNotifier.java
@@ -11,7 +11,7 @@ class Slf4jNotifier implements Notifier {
   private final Logger log;
 
   Slf4jNotifier(final String name) {
-    this.log = LoggerFactory.getLogger("WireMock " + name);
+    this.log = LoggerFactory.getLogger("WireMock." + name);
   }
 
   @Override

--- a/src/test/java/test/LoggingTest.java
+++ b/src/test/java/test/LoggingTest.java
@@ -86,6 +86,9 @@ class LoggingTest {
             HttpResponse.BodyHandlers.ofString());
     assertThat(response.body()).isEqualTo("Hello World!");
     assertThat(capturedOutput.getAll())
+        .as("Must contain correct logger name")
+        .contains("WireMock.todo-service", "WireMock.user-service");
+    assertThat(capturedOutput.getAll())
         .as("Must contain debug logging for WireMock")
         .contains("Matched response definition:");
   }


### PR DESCRIPTION
Separate wiremock server logger name with a "." instead of a space, making it easier to adjust log level in Spring for all wiremock servers with `logging.level.WireMock: WARN` for example.

## References

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
