### PR TITLE
feat: make @EnableWireMock repeatable

### DIFF
--- a/src/main/java/org/wiremock/spring/EnableWireMock.java
+++ b/src/main/java/org/wiremock/spring/EnableWireMock.java
@@ -2,6 +2,7 @@ package org.wiremock.spring;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(org.wiremock.spring.internal.WireMockSpringJunitExtension.class)
+@Repeatable(EnableWireMocks.class)
 public @interface EnableWireMock {
   /**
    * A list of {@link com.github.tomakehurst.wiremock.WireMockServer} configurations. For each

--- a/src/main/java/org/wiremock/spring/EnableWireMocks.java
+++ b/src/main/java/org/wiremock/spring/EnableWireMocks.java
@@ -1,0 +1,14 @@
+package org.wiremock.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableWireMocks {
+  EnableWireMock[] value();
+}

--- a/src/main/java/org/wiremock/spring/internal/WireMockContextCustomizerFactory.java
+++ b/src/main/java/org/wiremock/spring/internal/WireMockContextCustomizerFactory.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.ContextCustomizerFactory;
@@ -56,8 +56,9 @@ public class WireMockContextCustomizerFactory implements ContextCustomizerFactor
 
   private List<EnableWireMock> getEnableWireMockAnnotations(final Class<?> testClass) {
     final List<EnableWireMock> annotations = new ArrayList<>();
-    Optional.ofNullable(AnnotationUtils.findAnnotation(testClass, EnableWireMock.class))
-        .ifPresent(it -> annotations.add(it));
+    Optional.ofNullable(
+            AnnotationSupport.findRepeatableAnnotations(testClass, EnableWireMock.class))
+        .ifPresent(annotations::addAll);
 
     Arrays.asList(testClass.getEnclosingClass(), testClass.getSuperclass()).stream()
         .filter(clazz -> clazz != null)

--- a/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
+++ b/src/main/java/org/wiremock/spring/internal/WireMockSpringJunitExtension.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.wiremock.spring.ConfigureWireMock;
 import org.wiremock.spring.EnableWireMock;
 import org.wiremock.spring.InjectWireMock;
@@ -92,7 +91,10 @@ public class WireMockSpringJunitExtension
 
   private List<EnableWireMock> getEnableWireMockAnnotations(List<Object> instances) {
     return instances.stream()
-        .map(it -> AnnotationUtils.findAnnotation(it.getClass(), EnableWireMock.class))
+        .flatMap(
+            it ->
+                AnnotationSupport.findRepeatableAnnotations(it.getClass(), EnableWireMock.class)
+                    .stream())
         .filter(it -> it != null)
         .toList();
   }

--- a/src/test/java/test/MetaAnnotationTest.java
+++ b/src/test/java/test/MetaAnnotationTest.java
@@ -1,0 +1,42 @@
+package test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.wiremock.spring.ConfigureWireMock;
+import org.wiremock.spring.EnableWireMock;
+import org.wiremock.spring.InjectWireMock;
+
+@SpringBootTest(classes = WireMockSpringExtensionTest.AppConfiguration.class)
+@EnableWireMock({@ConfigureWireMock(name = "direct-wiremock")})
+@MetaAnnotationTest.MetaAnnotation
+public class MetaAnnotationTest {
+
+  @SpringBootApplication
+  static class AppConfiguration {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @SpringBootTest
+  @EnableWireMock(@ConfigureWireMock(name = "meta-wiremock"))
+  @interface MetaAnnotation {}
+
+  @InjectWireMock("direct-wiremock")
+  private WireMockServer directWireMock;
+
+  @InjectWireMock("meta-wiremock")
+  private WireMockServer metaWireMockServer;
+
+  @Test
+  void metaAnnotationAndDirectAnnotationBothGetRegistered() {
+    assertThat(directWireMock).isNotNull();
+    assertThat(metaWireMockServer).isNotNull();
+  }
+}


### PR DESCRIPTION
Make the @EnableWiremock annotation repeatable. This allows for example one wiremock instance to come from a meta annotation and one wiremock instance from a direct registration