### PR TITLE
fix: Fix WireMockServerCreator logger name

### DIFF
--- a/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
+++ b/wiremock-spring-boot/src/main/java/org/wiremock/spring/internal/WireMockServerCreator.java
@@ -28,7 +28,7 @@ public class WireMockServerCreator {
   private final Logger logger;
 
   public WireMockServerCreator(final String name) {
-    this.logger = LoggerFactory.getLogger(WireMockServerCreator.class + " " + name);
+    this.logger = LoggerFactory.getLogger(WireMockServerCreator.class.getName() + "." + name);
   }
 
   public WireMockServer createWireMockServer(


### PR DESCRIPTION
This fixes #201. 

## Background

WireMockServerCreator creates its logger using:

```
this.logger = LoggerFactory.getLogger(WireMockServerCreator.class + " " + name);
```

This makes `WireMockServerCreator.class` return  `Class.toString()` instead of `Class.getName()`. The resulting logger name is: `class org.wiremock.spring.internal.WireMockServerCreator wiremock`

Since the logger name isn't a real dotted path, it's impossible to configure via the normal Logback/Spring Boot hierarchy mechanism. `logging.level.org.wiremock.spring=WARN` (which correctly silences `Store`, `WireMockContextCustomizer`, etc.) does not affect this logger.

This means all the `logger.info(...)` calls in `WireMockServerCreator` — "Looking for mocks in
directory ...", "Configuring WireMockServer ...", etc. cannot be suppressed through standard configuration.


## References

* https://github.com/wiremock/wiremock-spring-boot/issues/201

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
